### PR TITLE
feat: Support private registry host

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 ## Configuration
 
-Your credentials have to be configured with the environment variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`. If you are using a private docker registry, set its URL in the environment variable `DOCKER_REGISTRY`.
+Your credentials have to be configured with the environment variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`.
 
 In addition, you need to specify the name of the image as the `name` setting in the publish step. If you need to specify a custom docker registry URL, add it as the `registryUrl` setting in the verifyConditions step.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
 ```json
 {
   "release": {
-    "verifyConditions": "semantic-release-docker",
+    "verifyConditions": {
+      "path": "semantic-release-docker",
+      "registryUrl": "docker.io"
+    },
     "publish": {
       "path": "semantic-release-docker",
       "name": "username/imagename"
@@ -29,7 +32,7 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 Your credentials have to be configured with the environment variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`. If you are using a private docker registry, set its URL in the environment variable `DOCKER_REGISTRY`.
 
-In addition, you need to specify the name of the image as the `name` setting.
+In addition, you need to specify the name of the image as the `name` setting in the publish step. If you need to specify a custom docker registry URL, add it as the `registryUrl` setting in the verifyConditions step.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 ## Configuration
 
-Your credentials have to be configured with the environment variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`.
+Your credentials have to be configured with the environment variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`. If you are using a private docker registry, set its URL in the environment variable `DOCKER_REGISTRY`.
 
 In addition, you need to specify the name of the image as the `name` setting.
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,9 +7,18 @@ module.exports = async (pluginConfig, { logger }) => {
     }
   }
   try {
-    await execa('docker', ['login', '-u=' + process.env.DOCKER_USERNAME, '-p=' + process.env.DOCKER_PASSWORD], {
-      stdio: 'inherit',
-    })
+    await execa(
+      'docker',
+      [
+        'login',
+        process.env.DOCKER_REGISTRY || '',
+        '-u=' + process.env.DOCKER_USERNAME,
+        '-p=' + process.env.DOCKER_PASSWORD,
+      ],
+      {
+        stdio: 'inherit',
+      }
+    )
   } catch (err) {
     throw new Error('docker login failed')
   }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -11,7 +11,7 @@ module.exports = async (pluginConfig, { logger }) => {
       'docker',
       [
         'login',
-        process.env.DOCKER_REGISTRY || '',
+        pluginConfig.registryUrl || '',
         '-u=' + process.env.DOCKER_USERNAME,
         '-p=' + process.env.DOCKER_PASSWORD,
       ],


### PR DESCRIPTION
This pull request adds support for non-default docker hosts (such as self-hosted registries or services like Amazon ECR). It introduces an optional environment variable DOCKER_REGISTRY to denote the URL of the registry. If this variable is left blank, the default registry of the docker client (probably Docker Hub) will be used.