### PR TITLE
feat: support custom tags via templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
     },
     "publish": {
       "path": "semantic-release-docker",
-      "name": "username/imagename"
+      "name": "username/imagename",
+      "prodReleaseTags": [
+        "<full>",
+        "<major>.<minor>",
+        "<major>",
+        "latest",
+      ]
     }
   }
 }
@@ -42,7 +48,21 @@ Verify that all needed configuration is present and login to the Docker registry
 
 ### `publish`
 
-Tag the image specified by `name` with the new version, push it to Docker Hub and update the `latest` tag.
+Tag the image specified by `name` with the new version tags and push it to Docker Hub.
+
+| Options           | Description                                                     | Default                     |
+| ----------------- | --------------------------------------------------------------- | ----------------------------|
+| `name`            | The name of the image on docker hub (i.e. `username/imagename`) | *required*                  |
+| `prodReleaseTags` | Image tag templates for regular releases                        | `[ '<full>', 'latest' ]`    |
+| `preReleaseTags`  | Image tag templates for pre-releases                            | `[ '<full>', 'latest' ]`    |
+
+| Template Variable | Description             | Example: `4.7.11-beta.1` |
+| ----------------- | ----------------------- | ------------------------ |
+| `<full>`          | The full semver version | `4.7.11-beta.1`          |
+| `<major>`         | The major version       | `4`                      |
+| `<minor>`         | The minor version       | `7`                      |
+| `<patch>`         | The patch version       | `11`                     |
+| `<channel>`       | The pre-release channel | `beta`                   |
 
 ## Example .travis.yml
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,10 +1,29 @@
 const execa = require('execa')
+const semver = require('semver')
 
 module.exports = async (pluginConfig, { nextRelease: { version }, logger }) => {
-  logger.log(`Pushing version ${pluginConfig.name}:${version} to docker hub`)
+  const publish = tag => {
+    logger.log(`Pushing version ${pluginConfig.name}:${tag} to docker hub`)
+    if (tag !== 'latest') {
+      execa('docker', ['tag', `${pluginConfig.name}:latest`, `${pluginConfig.name}:${tag}`], { stdio: 'inherit' })
+    }
+    execa('docker', ['push', `${pluginConfig.name}:${tag}`], { stdio: 'inherit' })
+  }
 
-  // Push both new version and latest
-  execa('docker', ['tag', `${pluginConfig.name}:latest`, `${pluginConfig.name}:${version}`], { stdio: 'inherit' })
-  execa('docker', ['push', `${pluginConfig.name}:${version}`], { stdio: 'inherit' })
-  execa('docker', ['push', `${pluginConfig.name}:latest`], { stdio: 'inherit' })
+  const v = semver.parse(version)
+
+  let tags = ['<full>', 'latest']
+  if (v.prerelease.length === 0) {
+    tags = pluginConfig.prodReleaseTags || tags
+  } else {
+    tags = pluginConfig.preReleaseTags || tags
+    tags = tags.map(tag => tag.replace(/<channel>/, [v.prerelease]))
+  }
+
+  tags
+    .map(tag => tag.replace(/<major>/, v.major))
+    .map(tag => tag.replace(/<minor>/, v.minor))
+    .map(tag => tag.replace(/<patch>/, v.patch))
+    .map(tag => tag.replace(/<full>/, version))
+    .forEach(publish)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,6 +920,14 @@
         "semver": "^5.5.0",
         "split": "^1.0.0",
         "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "conventional-commit-types": {
@@ -1000,6 +1008,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "currently-unhandled": {
@@ -1318,6 +1333,12 @@
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -1445,6 +1466,14 @@
         "minimatch": "^3.0.4",
         "resolve": "^1.3.3",
         "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-prettier": {
@@ -3032,6 +3061,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-url": {
@@ -7372,13 +7409,19 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-regex": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@semantic-release/error": "^2.1.0",
-    "execa": "^4.0.0"
+    "execa": "^4.0.0",
     "semver": "^7.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@semantic-release/error": "^2.1.0",
-    "execa": "^0.10.0"
+    "execa": "^0.10.0",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",


### PR DESCRIPTION
This pull request adds support for custom tags via templates provided by config options `prodReleaseTags` and `preReleaseTags`. The options are kept optional so this doesn't introduce a breaking change.

Resolves #34 